### PR TITLE
Update template to work for 1.21

### DIFF
--- a/ModTemplate/ModTemplate.csproj
+++ b/ModTemplate/ModTemplate.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <OutputPath>bin\$(Configuration)\Mods\mod</OutputPath>
   </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Vintage Story Mod Template
 
-This repository contains a configured .NET 7 mod for Visual Studio, Visual Studio Code and Rider that let's you start Vintage Story and add your own code to it. Supports logging and as well as debugging.
+This repository contains a configured .NET 8 mod for Visual Studio, Visual Studio Code and Rider that let's you start Vintage Story and add your own code to it. Supports logging and as well as debugging.
 
 
 
@@ -20,7 +20,7 @@ This will then produce the `mymodid_1.0.0.zip` inside the `Release` folder in th
 
 
 ##  Linux / Mac
-This sample is preconfigured for Windows if you want to use it on Linux or Mac you need to change the path for the Vintage Story (Server) binaries since those are now platform dependent with .NET 7. 
+This sample is preconfigured for Windows if you want to use it on Linux or Mac you need to change the path for the Vintage Story (Server) binaries since those are now platform dependent with .NET 8. 
 
 ### Rider
 If you use Rider on Linux or Mac you will need to change in
@@ -37,7 +37,7 @@ to
 
 ## Info General
 
-Since version 1.18.8-rc1 Vintage Story uses .NET 7 as its base framework. This means from now on mods can be targeted towards it and make use of the latest C# 11 language features.
+Since version 1.21 Vintage Story uses .NET 8 as its base framework. This means from now on mods can be targeted towards it and make use of the latest C# language features.
 
 Further the new way of creating mods uses a [dotnet template package](https://www.nuget.org/packages/VintageStory.Mod.Templates/).
 
@@ -60,11 +60,11 @@ But that is not all cake can do for us.
 Since we use the `Cake Frosting` setup which essentially adds another Project to our solution where we can write C# code to define our build and package procedure. Further we added a Json Validation step to it so before a build is made it will verify that all json files are at least parsable by `Newtonsoft.Json` to avoid simple mistakes. And if you want to use any Testing library you can also add it to the Cake build system to run your test when you create a mod.zip for release.
 
 
-## Migrating Mods to .NET 7
+## Migrating Mods to .NET 8
 
-To migrate your mod to .NET 7 we would recommend you to create a new project with our new template (checkout our updated [wiki page](https://wiki.vintagestory.at/index.php/Modding:Setting_up_your_Development_Environment) for that) and copy over your old code. Additionally you may need to add any special references you need for your mod.
+To migrate your mod to .NET 8 we would recommend you to create a new project with our new template (checkout our updated [wiki page](https://wiki.vintagestory.at/index.php/Modding:Setting_up_your_Development_Environment) for that) and copy over your old code. Additionally you may need to add any special references you need for your mod.
 
-Then you may have to make some code changes so your mod works with the .NET 7 version of the game. For most mods this should be just minor changes.
+Then you may have to make some code changes so your mod works with the .NET 8 version of the game. For most mods this should be just minor changes.
 
-Once that is done it should be ready to be started within you preferred IDE. So you can also benefit from new C# 11 language features as well as the cake build system.
+Once that is done it should be ready to be started within you preferred IDE. So you can also benefit from new C# language features as well as the cake build system.
 


### PR DESCRIPTION
I wanted to use this mod template to get started with modding VintageStory 1.21. It turned out that the modding template hasnt been made compatible with 1.21's NET 8.0 requirement.

I figured i do it for you. Its just a single project change and a few tiny readme changes.
<img width="1227" height="138" alt="grafik" src="https://github.com/user-attachments/assets/6d3deaf1-0176-458b-b0e9-bb26f94e4182" />
